### PR TITLE
Clearer protocol implementation

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -6,19 +6,17 @@ version = 3
 name = "aardvark-rp2040-clone"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "base64",
  "cortex-m",
  "cortex-m-rt",
  "embedded-hal",
  "embedded-time",
  "heapless",
- "numtoa",
  "rp-pico",
  "rp2040-boot2",
  "serde",
  "serde-json-core",
- "ufmt",
+ "serde_repr",
  "usb-device",
  "usbd-hid",
  "usbd-serial",
@@ -342,12 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numtoa"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
-
-[[package]]
 name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +558,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,33 +603,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "ufmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
-dependencies = [
- "ufmt-macros",
- "ufmt-write",
-]
-
-[[package]]
-name = "ufmt-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "ufmt-write"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -35,15 +35,11 @@ heapless = { version = "0.7.10", features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde-json-core = "0.4.0"
 
-# To convert integer
-numtoa = "0.2.4"
-
-#
-arrayvec = { version = "0.7.2", default-features = false }
+# To encode basic types in json
+serde_repr = "0.1.9"
 
 # To provide base64 algo
 base64 = { version = "0.13.0", default-features = false }
-ufmt = "0.2.0"
 
 [features]
 boot2 = ["rp2040-boot2"]

--- a/firmware/src/application/protocol.rs
+++ b/firmware/src/application/protocol.rs
@@ -12,35 +12,35 @@ pub const MAX_MSG_SIZE: usize = 128;
 /// Represents the command codes as an enum
 //#[derive(Deserialize_repr, Debug)]
 pub enum CommandCode {
-	SetDirection,
-	WriteValue,
-	ReadValue,
-	Test,
+    SetDirection,
+    WriteValue,
+    ReadValue,
+    Test,
 }
 
 impl CommandCode {
-	pub fn from_u8(x: u8) -> Option<Self> {
-		match x {
-			0  => Some(Self::SetDirection),
-			1  => Some(Self::WriteValue),
-			2  => Some(Self::ReadValue),
-			10 => Some(Self::Test),
-			_  => None
-		}
-	}
+    pub fn from_u8(x: u8) -> Option<Self> {
+        match x {
+            0  => Some(Self::SetDirection),
+            1  => Some(Self::WriteValue),
+            2  => Some(Self::ReadValue),
+            10 => Some(Self::Test),
+            _  => None
+        }
+    }
 }
 
 /// Represents a command from the host
 #[derive(Deserialize, Debug)]
 pub struct Command {
-	/// Command code as u8
-	pub cod: u8,
+    /// Command code as u8
+    pub cod: u8,
 
-	/// id of targetted pin (X => gpioX)
-	pub pin: u8,
+    /// id of targetted pin (X => gpioX)
+    pub pin: u8,
 
-	/// argument value
-	pub arg: u8,
+    /// argument value
+    pub arg: u8,
 }
 
 // ============================================================================
@@ -52,79 +52,79 @@ pub type AnswerText = String<MAX_MSG_SIZE>;
 #[derive(Serialize_repr, Debug)]
 #[repr(u8)]
 pub enum AnswerStatus {
-	Ok    = 0u8,
-	Error = 1u8
+    Ok    = 0u8,
+    Error = 1u8
 }
 
 /// Represenattion of an answer
 #[derive(Serialize, Debug)]
 pub struct Answer {
-	/// Status code
-	pub sts: AnswerStatus,
+    /// Status code
+    pub sts: AnswerStatus,
 
-	/// ID of target pin (X => gpioX)
-	pub pin: u8,
+    /// ID of target pin (X => gpioX)
+    pub pin: u8,
 
-	/// Argument value
-	pub arg: u8,
+    /// Argument value
+    pub arg: u8,
 
-	/// Text message
-	pub msg: AnswerText,
+    /// Text message
+    pub msg: AnswerText,
 }
 
 impl Answer {
-	pub fn ok(pin: u8, arg: u8, msg: AnswerText) -> Self {
-		Self {
-			sts: AnswerStatus::Ok,
-			pin: pin,
-			arg: arg,
-			msg: msg,
-		}
-	}
+    pub fn ok(pin: u8, arg: u8, msg: AnswerText) -> Self {
+        Self {
+            sts: AnswerStatus::Ok,
+            pin: pin,
+            arg: arg,
+            msg: msg,
+        }
+    }
 
-	pub fn error(pin: u8, arg: u8, msg: AnswerText) -> Self {
-		Self {
-			sts: AnswerStatus::Error,
-			pin: pin,
-			arg: arg,
-			msg: msg,
-		}
-	}
+    pub fn error(pin: u8, arg: u8, msg: AnswerText) -> Self {
+        Self {
+            sts: AnswerStatus::Error,
+            pin: pin,
+            arg: arg,
+            msg: msg,
+        }
+    }
 }
 
 // ============================================================================
 
 /// Possible argument values for pin output value
 pub enum CmdPinWriteValue {
-	Low,
-	High
+    Low,
+    High
 }
 
 impl CmdPinWriteValue {
-	pub fn from_u8(x: u8) -> Option<Self> {
-		match x {
-			0 => Some(Self::Low),
-			1 => Some(Self::High),
-			_ => None,
-		}
-	}
+    pub fn from_u8(x: u8) -> Option<Self> {
+        match x {
+            0 => Some(Self::Low),
+            1 => Some(Self::High),
+            _ => None,
+        }
+    }
 }
 
 
 /// Possible argument values for pin direction value
 pub enum CmdPinDirValue {
-	PullUpInput,
-	PullDownInput,
-	ReadableOutput,
+    PullUpInput,
+    PullDownInput,
+    ReadableOutput,
 }
 
 impl CmdPinDirValue {
-	pub fn from_u8(x: u8) -> Option<Self> {
-		match x {
-			0 => Some(Self::PullUpInput),
-			1 => Some(Self::PullDownInput),
-			2 => Some(Self::ReadableOutput),
-			_ => None
-		}
-	}
+    pub fn from_u8(x: u8) -> Option<Self> {
+        match x {
+            0 => Some(Self::PullUpInput),
+            1 => Some(Self::PullDownInput),
+            2 => Some(Self::ReadableOutput),
+            _ => None
+        }
+    }
 }

--- a/firmware/src/application/protocol.rs
+++ b/firmware/src/application/protocol.rs
@@ -1,0 +1,130 @@
+use serde::{Deserialize, Serialize};
+use serde_repr::{Serialize_repr};
+use heapless::String;
+
+// ============================================================================
+
+/// Max message string length in answer
+pub const MAX_MSG_SIZE: usize = 128;
+
+// ============================================================================
+
+/// Represents the command codes as an enum
+//#[derive(Deserialize_repr, Debug)]
+pub enum CommandCode {
+	SetDirection,
+	WriteValue,
+	ReadValue,
+	Test,
+}
+
+impl CommandCode {
+	pub fn from_u8(x: u8) -> Option<Self> {
+		match x {
+			0  => Some(Self::SetDirection),
+			1  => Some(Self::WriteValue),
+			2  => Some(Self::ReadValue),
+			10 => Some(Self::Test),
+			_  => None
+		}
+	}
+}
+
+/// Represents a command from the host
+#[derive(Deserialize, Debug)]
+pub struct Command {
+	/// Command code as u8
+	pub cod: u8,
+
+	/// id of targetted pin (X => gpioX)
+	pub pin: u8,
+
+	/// argument value
+	pub arg: u8,
+}
+
+// ============================================================================
+
+/// Type for anwser text
+pub type AnswerText = String<MAX_MSG_SIZE>;
+
+/// Answer status code
+#[derive(Serialize_repr, Debug)]
+#[repr(u8)]
+pub enum AnswerStatus {
+	Ok    = 0u8,
+	Error = 1u8
+}
+
+/// Represenattion of an answer
+#[derive(Serialize, Debug)]
+pub struct Answer {
+	/// Status code
+	pub sts: AnswerStatus,
+
+	/// ID of target pin (X => gpioX)
+	pub pin: u8,
+
+	/// Argument value
+	pub arg: u8,
+
+	/// Text message
+	pub msg: AnswerText,
+}
+
+impl Answer {
+	pub fn ok(pin: u8, arg: u8, msg: AnswerText) -> Self {
+		Self {
+			sts: AnswerStatus::Ok,
+			pin: pin,
+			arg: arg,
+			msg: msg,
+		}
+	}
+
+	pub fn error(pin: u8, arg: u8, msg: AnswerText) -> Self {
+		Self {
+			sts: AnswerStatus::Error,
+			pin: pin,
+			arg: arg,
+			msg: msg,
+		}
+	}
+}
+
+// ============================================================================
+
+/// Possible argument values for pin output value
+pub enum CmdPinWriteValue {
+	Low,
+	High
+}
+
+impl CmdPinWriteValue {
+	pub fn from_u8(x: u8) -> Option<Self> {
+		match x {
+			0 => Some(Self::Low),
+			1 => Some(Self::High),
+			_ => None,
+		}
+	}
+}
+
+
+/// Possible argument values for pin direction value
+pub enum CmdPinDirValue {
+	PullUpInput,
+	PullDownInput,
+	ReadableOutput,
+}
+
+impl CmdPinDirValue {
+	pub fn from_u8(x: u8) -> Option<Self> {
+		match x {
+			0 => Some(Self::PullUpInput),
+			1 => Some(Self::PullDownInput),
+			2 => Some(Self::ReadableOutput),
+			_ => None
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors the protocol implementation in a separate module for clearer implementation using some enums and stuff.

- `cod` could be directly represented as a `CommandCode` in the `Command` structure using the `serde_repr` module, but deserializer's error messages are not clear enough to know the error's origin. This is why the `cod` field in `Command` structure is still stored as an `u8`, and the `CommandCode` enum implements a `from_u8` constructor
- `AnswerStatus` uses the `serde_repr` crate to be transparently encoded as an `u8` in the `Answer` structure
- Error messages have been improved